### PR TITLE
add version and healthz endpoints

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,12 @@
+* Added /version URL route (#2).
+    
+    /version returns a JSON object with detailed information of the build environment, 
+    including current commit and go version used to build the app. The binary must be built
+    with the release script in order for the correct values to be set.
+    
+* Added /healthz URL route (#2).
+
+    /healthz returns either a 200 OK status or a 500 error depending on the status of the app. 
+    Currently, a 500 error is returned only if the repo path is not valid.
+
 * Fixed panic when 0 arguments were passed (#06e92dd).

--- a/release.sh
+++ b/release.sh
@@ -2,6 +2,11 @@
 
 VERSION="$(git describe --tags --always --dirty)"
 NAME=squirrel
+USER=$(whoami)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+REVISION=$(git rev-parse HEAD)
+GOVERSION=$(go version | awk '{print $3}')
 
 echo "Building $NAME version $VERSION"
 
@@ -11,7 +16,11 @@ build() {
   echo -n "=> $1-$2: "
   GOOS=$1 GOARCH=$2 CGO_ENABLED=0 go build -o build/$NAME-$1-$2 -ldflags "\
       -X github.com/micromdm/squirrel/version.version=${VERSION}\
-      -X github.com/micromdm/squirrel/version.appName=${NAME}\
+      -X github.com/micromdm/squirrel/version.branch=${BRANCH}\
+      -X github.com/micromdm/squirrel/version.buildUser=${USER}\
+      -X github.com/micromdm/squirrel/version.buildDate=${NOW}\
+      -X github.com/micromdm/squirrel/version.revision=${REVISION}\
+      -X github.com/micromdm/squirrel/version.goVersion=${GOVERSION}\
       " ./main.go
   du -h build/$NAME-$1-$2
 }


### PR DESCRIPTION
/healthz returns 200 OK of 500 Internal Server Error depending on
weather the app is running healthy or not.
Currently the status is determined by wether the -repo path is valid.

the /version endpoint shows build information for the binary.